### PR TITLE
Feature/ci vhdl

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,18 @@ jobs:
         pip install -r python/requirements.txt
         pip install pytest tox
 
-    - name: Install SWIG
-      run: sudo apt-get install swig
+    - name: Install SWIG (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        # sudo apt-get install swig
+        mkdir swig
+        cd swig
+        wget http://prdownloads.sourceforge.net/swig/swig-4.0.1.tar.gz
+        tar -xf swig-4.0.1.tar.gz
+        cd swig-4.0.1
+        ./configure
+        make
+        sudo make install
         
     - name: Try Build
       run: |

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -36,6 +36,7 @@ jobs:
         tar -xf swig-4.0.1.tar.gz
         cd swig-4.0.1
         ./configure
+        make
         sudo make install
         
     

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python
 
 on: [push]
 
@@ -38,7 +38,7 @@ jobs:
       if: runner.os == 'Windows'
       run: choco install swig
 
-    - name: Test with pytest
+    - name: Build & Test with Pytest
       if: runner.os != 'Windows'
       run: |
         cd python

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -28,7 +28,16 @@ jobs:
     
     - name: Install SWIG (Linux)
       if: runner.os == 'Linux'
-      run: sudo apt-get install swig
+      run: |
+        # sudo apt-get install swig
+        mkdir swig
+        cd swig
+        wget http://prdownloads.sourceforge.net/swig/swig-4.0.1.tar.gz
+        tar -xf swig-4.0.1.tar.gz
+        cd swig-4.0.1
+        ./configure
+        sudo make install
+        
     
     - name: Install SWIG (Mac)
       if: runner.os == 'macOS'

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install GHDL and Python Dependencies
       run: |
+        sudo apt update
+        sudo apt install -y git make gnat zlib1g-dev
         wget https://github.com/tgingold/ghdl/releases/download/v0.33/ghdl_0.33-1ubuntu1_amd64.deb
         sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
         # sudo apt-get install ghdl

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Install GHDL and Python Dependencies
       run: |
-        sudo apt update
-        #sudo apt install -y git make gnat zlib1g-dev
+        sudo apt-get update
+        #sudo apt-get install -y git make gnat zlib1g-dev
         #wget https://github.com/tgingold/ghdl/releases/download/v0.33/ghdl_0.33-1ubuntu1_amd64.deb
         #sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
         sudo apt-get install ghdl

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Install GHDL and Python Dependencies
       run: |
         sudo apt update
-        sudo apt install -y git make gnat zlib1g-dev
-        wget https://github.com/tgingold/ghdl/releases/download/v0.33/ghdl_0.33-1ubuntu1_amd64.deb
-        sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
-        # sudo apt-get install ghdl
+        #sudo apt install -y git make gnat zlib1g-dev
+        #wget https://github.com/tgingold/ghdl/releases/download/v0.33/ghdl_0.33-1ubuntu1_amd64.deb
+        #sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
+        sudo apt-get install ghdl
         python -m pip install --upgrade pip
         pip install -r vivado/requirements.txt
 

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  python_unit_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - uses: actions/cache@v1
+      # Use Cache, see: https://github.com/actions/cache
+      if: startsWith(runner.os, 'Linux')
+      id: cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install GHDL and Python Dependencies
+      run: |
+        sudo apt-get install ghdl
+        python -m pip install --upgrade pip
+        pip install -r vivado/requirements.txt
+
+    - name: Test
+      run: |
+        cd vivado/NN_IP/EggNet_1.0/sim/MemCtrl/xsim
+        python tb_MemCtrl_run_sim.py

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -51,5 +51,5 @@ jobs:
     - name: Test
       run: |
         pwd
-        cd vivado/NN_IP/EggNet_1.0/sim/MemCtrl/xsim
+        cd vivado/NN_IP/EggNet_1.0/sim/MemCtrl/
         python tb_MemCtrl_run_sim.py

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -1,4 +1,4 @@
-name: CI
+name: VHDL Testbenches
 
 on: [push, pull_request]
 
@@ -25,7 +25,9 @@ jobs:
 
     - name: Install GHDL and Python Dependencies
       run: |
-        sudo apt-get install ghdl
+        wget https://github.com/tgingold/ghdl/releases/download/v0.33/ghdl_0.33-1ubuntu1_amd64.deb
+        sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
+        # sudo apt-get install ghdl
         python -m pip install --upgrade pip
         pip install -r vivado/requirements.txt
 

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   python_unit_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v1
     
@@ -26,7 +26,7 @@ jobs:
     - name: Install GHDL
       run: |
         sudo apt-get update
-        sudo apt-get install llvm libgnat libc6 # Used by 
+        sudo apt-get install llvm libgnat-6 libc6 # Used by 
         
         # Install GHDL
         mkdir ghdl

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -3,7 +3,7 @@ name: VHDL Testbenches
 on: [push, pull_request]
 
 jobs:
-  python_unit_test:
+  vhdl_testbenches:
     runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -23,17 +23,33 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Install GHDL and Python Dependencies
+    - name: Install GHDL
       run: |
         sudo apt-get update
-        #sudo apt-get install -y git make gnat zlib1g-dev
-        #wget https://github.com/tgingold/ghdl/releases/download/v0.33/ghdl_0.33-1ubuntu1_amd64.deb
-        #sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
-        sudo apt-get install ghdl
+        sudo apt-get install llvm libgnat libc6 # Used by 
+        
+        # Install GHDL
+        mkdir ghdl
+        cd ghdl
+        wget https://github.com/ghdl/ghdl/releases/download/v0.36/ghdl-0.36-ubuntu14-llvm-3.8.tgz
+        tar -xf ghdl-0.36-ubuntu14-llvm-3.8.tgz
+        # Find better way to install
+        chmod +x bin/*
+        mv bin/* /usr/local/bin
+        mv lib/* /usr/local/lib
+        mv include/* /usr/local/include
+        
+        # sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
+        # sudo apt-get install ghdl
+  
+    - name: Install Python Dependencies
+      run: |
+        pwd        
         python -m pip install --upgrade pip
         pip install -r vivado/requirements.txt
 
     - name: Test
       run: |
+        pwd
         cd vivado/NN_IP/EggNet_1.0/sim/MemCtrl/xsim
         python tb_MemCtrl_run_sim.py

--- a/.github/workflows/vhdl.yml
+++ b/.github/workflows/vhdl.yml
@@ -35,9 +35,9 @@ jobs:
         tar -xf ghdl-0.36-ubuntu14-llvm-3.8.tgz
         # Find better way to install
         chmod +x bin/*
-        mv bin/* /usr/local/bin
-        mv lib/* /usr/local/lib
-        mv include/* /usr/local/include
+        sudo mv bin/* /usr/local/bin
+        sudo mv lib/* /usr/local/lib
+        sudo mv include/* /usr/local/include
         
         # sudo dpkg --install ghdl_0.33-1ubuntu1_amd64.deb
         # sudo apt-get install ghdl

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # MNIST on FPGA
 
-![General CI Badge](https://github.com/marbleton/FPGA_MNIST/workflows/CI/badge.svg)
-![Python-Package CI Badge](https://github.com/marbleton/FPGA_MNIST/workflows/Python%20package/badge.svg)
 ![GitHub](https://img.shields.io/github/license/marbleton/FPGA_MNIST)
+
+![General CI Badge](https://github.com/marbleton/FPGA_MNIST/workflows/CI/badge.svg)
+![Python-Package CI Badge](https://github.com/marbleton/FPGA_MNIST/workflows/Python/badge.svg)
+![Python-Package CI Badge](https://github.com/marbleton/FPGA_MNIST/workflows/VHDL%20Testbenches/badge.svg)
+
+
+
 
 This is a university project at TU Vienna to create a neural network hardware accelerator with an FPGA.
 

--- a/vivado/requirements.txt
+++ b/vivado/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib


### PR DESCRIPTION
# VHDL Testbench Continous Testing

Updated all Github Workflow Scripts. All should build now MacOS and Linux. There is a new Workflow which executes the VHDL test benches using the `tb_MemCtrl_run_sim.py` file. Testbenches are executed on every *push* and *pull request*.

Also added a `requirements.txt` file for the python test bench development.

The setup is done in: `.github/workflows/vhdl.yml`